### PR TITLE
Allow to iterate over resources

### DIFF
--- a/src/parts/resources.rs
+++ b/src/parts/resources.rs
@@ -41,6 +41,11 @@ impl Resources {
         };
         self.0.insert(id.to_owned(), inner);
     }
+
+    /// Return an iterator over the id-tag pairs of the resources, in their order
+    pub fn iter(&self) -> impl Iterator<Item=(&str, &str)> + '_ {
+        self.0.iter().map(|(id, inner)| (id.as_str(), inner.tag.as_str()))
+    }
 }
 
 fn empty_object() -> ::serde_json::Value {

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -60,4 +60,22 @@ fn managed_ec2_batch_environment() {
     assert_eq!("JobQueue", output_queue_arn.value.as_reference().unwrap());
     let output_definition_arn = tpl.outputs().get::<String>("JobDefinitionArn").unwrap();
     assert_eq!("JobDefinition", output_definition_arn.value.as_reference().unwrap());
+
+    let resources: Vec<_> = tpl.resources().iter().collect();
+    assert_eq!(resources, [
+        ("VPC", "AWS::EC2::VPC"),
+        ("InternetGateway", "AWS::EC2::InternetGateway"),
+        ("RouteTable", "AWS::EC2::RouteTable"),
+        ("VPCGatewayAttachment", "AWS::EC2::VPCGatewayAttachment"),
+        ("SecurityGroup", "AWS::EC2::SecurityGroup"),
+        ("Subnet", "AWS::EC2::Subnet"),
+        ("Route", "AWS::EC2::Route"),
+        ("SubnetRouteTableAssociation", "AWS::EC2::SubnetRouteTableAssociation"),
+        ("BatchServiceRole", "AWS::IAM::Role"),
+        ("IamInstanceProfile", "AWS::IAM::InstanceProfile"),
+        ("EcsInstanceRole", "AWS::IAM::Role"),
+        ("JobDefinition", "AWS::Batch::JobDefinition"),
+        ("JobQueue", "AWS::Batch::JobQueue"),
+        ("ComputeEnvironment", "AWS::Batch::ComputeEnvironment"),
+    ]);
 }


### PR DESCRIPTION
Currently, it seems there is no way to iterate through resources unless you know ids and types. This PR adds the `iter` method and allow to access resources like:

```rust
let resources = tpl.resources();
for (id, tag) in resources.iter() {
    if tag == "AWS::EC2::VPC" {
        let resource = resources.get::<cfn::aws::ec2::VPC>(id).unwrap();
        dbg!(resource);
    }
}
```